### PR TITLE
fix: 페이지 버튼 클릭 방식 수정

### DIFF
--- a/src/main/webapp/WEB-INF/views/includes/header.jsp
+++ b/src/main/webapp/WEB-INF/views/includes/header.jsp
@@ -7,6 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="">
     <meta name="author" content="">
+    <meta id="_csrf" name="_csrf" content="${_csrf.token}" />
+    <meta id="_csrf_header" name="_csrf_header" content="${_csrf.headerName}" />
 
     <title>SB Admin 2 - Bootstrap Admin Theme</title>
 

--- a/src/main/webapp/WEB-INF/views/menu/info.jsp
+++ b/src/main/webapp/WEB-INF/views/menu/info.jsp
@@ -140,7 +140,7 @@
     <%@include file="../includes/plugin_js.jsp" %>
     
     <!-- import JS -->
-   	<script type="text/javascript" src="/resources/js/common.js?ver=0.1.1"></script>
+   	<script type="text/javascript" src="/resources/js/common.js?ver=0.1.2"></script>
     
     <script type="text/javascript" src="/resources/js/reply.js"></script>
     
@@ -428,6 +428,14 @@
 		// 페이지의 번호를 클릭했을 때 새로운 리뷰를 가져오게 함
 		replyPageFooter.on("click", "li a", function(e) {
 			
+			// 현재 페이지와 같은 페이지를 누를 경우
+			//if (pageNum == $(this).attr("href") ) {
+				
+			//	console.log("같은 페이지");
+			//	return false;
+				
+			//}
+						
 			e.preventDefault();
 			console.log("page click");
 			

--- a/src/main/webapp/WEB-INF/views/menu/list.jsp
+++ b/src/main/webapp/WEB-INF/views/menu/list.jsp
@@ -98,6 +98,14 @@
     		
     		// 페이지를 눌러 이동 시
     		$(".paginate_button a").on("click", function(e) {
+    			
+    			// 현재 페이지와 같은 페이지를 클릭할 경우
+				if (${pageMaker.cri.pageNum} == $(this).attr("href") ) {
+    				
+    				console.log("같은 페이지");
+    				return false;
+    				
+    			}
 
 				e.preventDefault();
 

--- a/src/main/webapp/resources/js/common.js
+++ b/src/main/webapp/resources/js/common.js
@@ -57,4 +57,10 @@ $(document).ready(function() {
 	
 	});
 	
+	var token = $("meta[name='_csrf']").attr("content");
+    var header = $("meta[name='_csrf_header']").attr("content");
+    $(document).ajaxSend(function(e, xhr, options) {
+        xhr.setRequestHeader(header, token);
+    });
+	
 });


### PR DESCRIPTION
- Ajax 요청이 스프링 시큐리티로 인해 403 Forbiden을 일으키는 문제 해결
(header meta 추가, common.js에 기능 추가)
- 메뉴 리스트 페이지에서 같은 페이지를 누를 시 동작이 안되도록 수정
- 인포 페이지에서 같은 리뷰 페이지를 누를 시 동작이 안되는 코드 추가(주석처리)

close #61 