### PR TITLE
feat: 메뉴 성분별 정렬 기능 추가

### DIFF
--- a/src/main/java/com/coffeereview/domain/Criteria.java
+++ b/src/main/java/com/coffeereview/domain/Criteria.java
@@ -16,6 +16,8 @@ import lombok.ToString;
 * 2020.11.23        SeongPyo Jo       최초 생성
 * 2020.11.23        SeongPyo Jo       검색 키워드 추가
 * 2020.11.23        SeongPyo Jo       리뷰 조회를 위한 생성자 추가
+* 2020.12.21        SeongPyo Jo       getPageStart 미사용으로 인한 주석 처리
+* 2020.12.21        SeongPyo Jo       정렬을 위한 변수 추가 (orderKeyword)
 */
 
 @Getter
@@ -34,6 +36,8 @@ public class Criteria {
 	private String type;
 	// 검색 키워드
 	private String keyword;
+	// 정렬 키워드
+	private String orderKeyword;
 	
 	public Criteria() {
 		
@@ -60,6 +64,7 @@ public class Criteria {
 		
 	}
 	
+	/*
 	public Criteria(int pageNum, int amount, String cafe) {
 		
 		if (pageNum <= 0) {
@@ -69,17 +74,13 @@ public class Criteria {
 			this.pageNum = pageNum;
 		}
 		
-		if (amount <= 0) {
-			this.amount = 10;
-		}
-		else {
-			this.amount = amount;
-		}
-		
+		this.amount = amount;
 		this.cafe = cafe;
 		
 	}
+	*/
 	
+	/*
 	// 시작 페이지를 반환해준다.
 	// MenuMapper.xml 에서 pageStart를 변수로 쓸 수 있다.
 	public int getPageStart() {
@@ -87,5 +88,6 @@ public class Criteria {
 		return (this.pageNum - 1) * this.amount;
 		
 	}
+	*/
 	
 }

--- a/src/main/resources/com/coffeereview/mapper/MenuMapper.xml
+++ b/src/main/resources/com/coffeereview/mapper/MenuMapper.xml
@@ -33,12 +33,7 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 			<if test='keyword != null and keyword neq ""'>
 				menu like CONCAT('%',#{keyword},'%')
 			</if>
-		</trim>
-		<trim suffix="AND">
-			<if test='cafe != null and cafe neq ""'>
-				cafe = #{cafe}
-			</if>
-		</trim>
+		</trim>		
 	</sql>
 	
 	<select id="getMenuListWithPaging" resultType="com.coffeereview.domain.MenuVO">
@@ -49,7 +44,20 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 			FROM
 				(
 					SELECT
-						mno, menu, cafe, star_avg, replycnt, ROW_NUMBER() OVER(ORDER BY star_avg DESC) as rn
+						*, ROW_NUMBER() OVER(ORDER BY 
+		]]>
+		
+						<choose>
+							<when test='orderKeyword != null and orderKeyword neq""'>
+								${orderKeyword}
+							</when>
+							<otherwise>
+								star_avg
+							</otherwise>
+						</choose>
+		
+		<![CDATA[
+						DESC) as rn
 					FROM
 						tbl_menu
 					WHERE
@@ -58,7 +66,7 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 			<include refid="criteria"></include>
 		
 		<![CDATA[
-						mno > 0
+				cafe = #{cafe} AND mno > 0
 		]]>
 		
 		<![CDATA[
@@ -78,7 +86,7 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 			
 			<include refid="criteria"></include>
 		
-			mno > 0
+			cafe = #{cafe} AND mno > 0
 	</select>
 	
 	<update id="updateReplyCnt">

--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -14,6 +14,9 @@
 	<logger name="com.coffeereview.controller">
 		<level value="debug" />
 	</logger>
+	<logger name="com.coffeereview.mapper">
+		<level value="debug" />
+	</logger>
 	
 	<!-- 3rdparty Loggers -->
 	<logger name="org.springframework.core">

--- a/src/main/webapp/WEB-INF/views/menu/info.jsp
+++ b/src/main/webapp/WEB-INF/views/menu/info.jsp
@@ -18,11 +18,12 @@
             <div class="row">
                 <div class="col-lg-12">                   
                    <form id='operForm' action="/menu/list" method="get">
-                      <input type='hidden' name='cafe' value='<c:out value="${cri.cafe}"/>'>
+                      <input type='hidden' name='cafe' value='<c:out value="${cri.cafe}"/>'>                      
                       <input type='hidden' name='keyword' value='<c:out value="${cri.keyword}"/>'>
+                      <input type='hidden' name='orderKeyword' value='<c:out value="${cri.orderKeyword}"/>'>
                       <input type='hidden' name='pageNum' value='<c:out value="${cri.pageNum}"/>'>
-                      <!-- <input type='hidden' name='amount' value='<c:out value="${cri.amount}"/>'> -->
                       <input type='hidden' id='mno' name='mno' value='<c:out value="${menuInfo.mno}"/>'>
+                      <!-- <input type='hidden' name='amount' value='<c:out value="${cri.amount}"/>'> -->
                    </form>
                    
                     <h1 class="page-header">${menuInfo.cafe} <button data-oper='list' class="btn btn-info pull-right">List</button></h1>
@@ -214,6 +215,22 @@
     $(document).ready(function() {
       
       var operForm = $("#operForm");
+      
+   		// orderKeyword의 값이 없을 경우 url 파라미터에서 제거
+		if (!operForm.find("input[name=orderKeyword]").val())	{
+			
+			console.log('orderKeyword is empty');
+			operForm.find("input[name=orderKeyword]").remove();
+			
+		}
+		
+		// keyword의 값이 없을 경우 url 파라미터에서 제거
+		if (!operForm.find("input[name=keyword]").val()) {
+			
+			console.log('keyword is empty');
+			operForm.find("input[name=keyword]").remove();
+			
+		}
       
       $("button[data-oper='list']").on("click", function(e) {
 

--- a/src/main/webapp/WEB-INF/views/menu/list.jsp
+++ b/src/main/webapp/WEB-INF/views/menu/list.jsp
@@ -18,10 +18,23 @@
             <div class="row">
                 <div class="col-lg-12">
                     <h1 class="page-header">메뉴</h1>
+                    <div class="form-group pull-right">
+			            <select class="form-control orderSelect">
+			            	<option value="" selected>정렬 선택</option>
+			               	<option value="star_avg">별점</option>
+			               	<option value="caffeine">카페인</option>
+			               	<option value="kcal">칼로리</option>
+			               	<option value="sodium">나트륨</option>
+			               	<option value="sugars">당분</option>
+			            </select>
+	            	</div>
                 </div>
                 <!-- /.col-lg-12 -->
             </div>
             <!-- /.row -->
+            
+            
+            
             <!-- 메뉴 목록 출력 -->
             <div class="row">
                 <c:forEach items="${list}" var="menuInfo">
@@ -32,7 +45,7 @@
 	                        		<c:out value="${menuInfo.menu}" />
 	                        	</div>
 	                        	<div class="panel-body p-0">
-	                        		<img src='/menu/display?menuName=STARBUCKS/<c:out value="${menuInfo.menu}"/>' class="full-width">
+	                        		<img src='/menu/display?menuName=<c:out value="${pageMaker.cri.cafe}" />/<c:out value="${menuInfo.menu}" />' class="full-width">
 	                        	</div>
 	                        	<div class="panel-footer list-star text-center">
 	                        		<i class="fa fa-star fa-fw m-0"></i>
@@ -49,11 +62,11 @@
             <!-- 메뉴 목록 출력 끝 -->
             
             <!-- 페이징 처리 -->
-            <div class="pull-right">
+            <div class="text-center">
             	<ul class="pagination">
             		<c:if test="${pageMaker.prev}">
             			<li class="paginate_button previous">
-            				<a href='<c:out value="${pageMaker.startPage - 1}"/>'>Previous</a>
+            				<a href='<c:out value="${pageMaker.startPage - 1}"/>'><i class="fa fa-angle-double-left"></i></a>
             			</li>
             		</c:if>
             			
@@ -65,7 +78,7 @@
             		
             		<c:if test="${pageMaker.next}">
             			<li class="paginate_button next">
-            				<a href='<c:out value="${pageMaker.endPage + 1}"/>'>Next</a>
+            				<a href='<c:out value="${pageMaker.endPage + 1}"/>'><i class="fa fa-angle-double-right"></i></a>
             			</li>
             		</c:if>            		
             	</ul>
@@ -73,7 +86,8 @@
             <form id='actionForm' action="/menu/list" method='get'>
             	<input type='hidden' name='cafe' value='<c:out value="${pageMaker.cri.cafe}" />'>
             	<input type='hidden' name='keyword' value='<c:out value="${pageMaker.cri.keyword}" />'>
-				<input type='hidden' name='pageNum' value='<c:out value="${pageMaker.cri.pageNum}" />'>
+            	<input type='hidden' name='orderKeyword' value='<c:out value="${pageMaker.cri.orderKeyword}" />'>
+				<input type='hidden' name='pageNum' value='<c:out value="${pageMaker.cri.pageNum}" />'>	
 				<!-- <input type='hidden' name='amount' value='<c:out value="${pageMaker.cri.amount}" />'> -->
 			</form>
             <!-- 페이징 처리 끝 -->            
@@ -94,7 +108,35 @@
     
     	$(document).ready(function() {
     		
-    		var actionForm = $("#actionForm");
+    		// 주소의 파라미터를 구하는 함수
+    		// $.urlParam(파라미터 이름);
+    		$.urlParam = function(name){
+    		    var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(window.location.href);
+    		    if (results==null){
+    		       return null;
+    		    }
+    		    else{
+    		       return results[1] || 0;
+    		    }
+    		}
+    		
+    		var actionForm = $("#actionForm");    		
+    		
+    		// orderKeyword의 값이 없을 경우 url 파라미터에서 제거
+    		if (!actionForm.find("input[name=orderKeyword]").val())	{
+    			
+    			console.log('orderKeyword is empty');
+    			actionForm.find("input[name=orderKeyword]").remove();
+    			
+    		}
+    		
+			// keyword의 값이 없을 경우 url 파라미터에서 제거
+    		if (!actionForm.find("input[name=keyword]").val()) {
+    			
+    			console.log('keyword is empty');
+    			actionForm.find("input[name=keyword]").remove();
+    			
+    		}
     		
     		// 페이지를 눌러 이동 시
     		$(".paginate_button a").on("click", function(e) {
@@ -111,7 +153,7 @@
 
 				console.log('click');
 
-				actionForm.find("input[name=pageNum]").val($(this).attr("href"));
+				actionForm.find("input[name=pageNum]").val($(this).attr("href"));			
 				
 				actionForm.submit();
 			});
@@ -125,6 +167,37 @@
     			actionForm.submit();
     			
     		});
+    		
+    		// 정렬을 위한 select option을 선택 시
+    		$(".orderSelect").on("change", function(e) {
+    			
+    			console.log("정렬 선택");
+    			
+    			if (!$(this).val()) {
+    				
+    				console.log("정렬 미선택");
+    				return false;
+    				
+    			}
+    			
+    			e.preventDefault();
+    			
+    			console.log('>> ' + $(this).val());
+    			
+    			if (!actionForm.find("input[name=orderKeyword]").val()) {    				
+    				
+    				actionForm.append("<input type='hidden' name='orderKeyword' value='" + $(this).val() + "'>");
+    				
+    			}
+    			else {
+    				
+    				actionForm.find("input[name=orderKeyword]").val($(this).val());
+    				
+    			}
+    			
+    			actionForm.submit();
+    			
+    		})
     
     	});
     

--- a/src/test/java/com/coffeereview/mapper/MenuMapperTests.java
+++ b/src/test/java/com/coffeereview/mapper/MenuMapperTests.java
@@ -70,8 +70,9 @@ public class MenuMapperTests {
 	@Test
 	public void testSearch() {
 		
-		Criteria cri = new Criteria(3, 10, "");
-		
+		Criteria cri = new Criteria(1, 10);
+		cri.setCafe("STARBUCKS");
+		cri.setOrderKeyword("abc");		
 		cri.setKeyword("");
 		
 		List<MenuVO> list = mapper.getMenuListWithPaging(cri);

--- a/target/classes/log4j.xml
+++ b/target/classes/log4j.xml
@@ -14,6 +14,9 @@
 	<logger name="com.coffeereview.controller">
 		<level value="debug" />
 	</logger>
+	<logger name="com.coffeereview.mapper">
+		<level value="debug" />
+	</logger>
 	
 	<!-- 3rdparty Loggers -->
 	<logger name="org.springframework.core">


### PR DESCRIPTION
- list.jsp, info.jsp에서 url 파라미터값이 공백인 경우 제거하는 기능 추가
- 정렬을 위한 orderKeyword 변수 추가(Keyword)
- View에 정렬 기능 추가(list.jsp)
- 정렬을 위한 sql문 변경(MenuMapper.xml -> getMenuListWithPaging)
- 기존 동적쿼리의 파라미터 중 cafe를 항상 사용하도록 sql 변경
(MenuMapper.xml -> getMenuListWithPaging)
- 페이지 출력 창 가운데 정렬(list.jsp)
- SQL 문을 Log4j에서 출력하도록 변경 (log4j.xml)

close #102 